### PR TITLE
Update README.md for wireguard

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Please uninstall the old ProtonVPN app before installing this package [(here: issue #3)](https://github.com/Zylquinal/protonvpn-bin/issues/3#issuecomment-1777776264).
 
+If upgrading from 4.2.0 to 4.3.0+, log out and log back in for wireguard to work.
+
 ## Remove the old protonvpn app
 
 ```bash


### PR DESCRIPTION
From my testing, if upgrading to 4.3.0 from a previous version, wireguard will not work until you log out and log back in, else it will throw expired certificate errors.